### PR TITLE
Fix nesting

### DIFF
--- a/sotd.py
+++ b/sotd.py
@@ -143,12 +143,12 @@ def getSchemaFields(localSchema, recommendedFields):
                                                 grandchildWt = (schema["definitions"][childdefItem]["properties"][grandchildItem]["weight"])/1000
                                             elif grandchildItem in schema["definitions"]:
                                                 if "weight" in schema["definitions"][grandchildItem]:
-                                                    childWt = (schema["definitions"][grandchildItem]["weight"]/1000)
+                                                    grandchildWt = (schema["definitions"][grandchildItem]["weight"]/1000)
                                                 else:
-                                                    childWt =  0.099
+                                                    grandchildWt =  0.099
                                             else:
-                                                childWt = 0.1
-                                            schemaSort.append([parentItem+"."+childItem+"."+grandchildItem, parentItem, parentWt, childWt, optWt])
+                                                grandchildWt = 0.1
+                                            schemaSort.append([parentItem+"."+childItem+"."+grandchildItem, parentItem, parentWt, grandchildWt, optWt])
 
         # Create and sort dataframe                            
         df = pd.DataFrame(schemaSort, columns=["Fields","Parent","ParentWeight","Weight", "OptionalWeight"])


### PR DESCRIPTION
Issue: 
Some fields were not showing up in Schema.csv as being in the Schema, in cases where they were.
e.g. with the field `recipientOrganization.location.latitude`

`recipientOrganization` is a definitions object (`Organization`), as is `location`, so we had a definitions object within a definitions object.

That meant that `recipientOrganization.location` (which is an object, not a field) was present in `schema.csv` but `recipientOrg.location.latitude` (a field) was tagged as 'FALSE' (not in Schema).